### PR TITLE
Fixed Statics CFG

### DIFF
--- a/GameData/StarshipLaunchExpansion/Parts/SSPads/SLE_SS_Statics.cfg
+++ b/GameData/StarshipLaunchExpansion/Parts/SSPads/SLE_SS_Statics.cfg
@@ -10,6 +10,15 @@ STATIC
 	cost = 20000	
 	manufacturer = SpaceX
 	description = Sam's Starship OLIT Base
+	VARIANT 
+	{
+	name = Exterior Structure Enabled
+	}
+	VARIANT 
+	{
+	name = Exterior Structure Disabled
+	deactivateTransforms = Exterior    // , seperated list of transforms to disable
+	}
 }
 
 


### PR DESCRIPTION
Added Variant for the OLIT base that was missing from the kerbal constructs static.