### PR TITLE
Fix to not being able to switch to the tower

### DIFF
--- a/GameData/StarshipLaunchExpansion/Parts/SSPads/SLE_SS_OLIT_Base.cfg
+++ b/GameData/StarshipLaunchExpansion/Parts/SSPads/SLE_SS_OLIT_Base.cfg
@@ -43,6 +43,7 @@ PART
 	breakingForce = 250000
 	breakingTorque = 250000
 	maxTemp = 10000 
+	vesselType = Probe
 	tags = Starship Super Heavy Booster SpaceX Landing Ship Launch Tower Base OLP Orbital Pad
 	
 	MODULE


### PR DESCRIPTION
added "vesselType = Probe" line to allow easy switching. you may switch it to a different vessel type if you wish to.