### PR TITLE
Fix URL property in version file

### DIFF
--- a/GameData/StarshipLaunchExpansion/Versioning/StarshipLaunchExpansion.version
+++ b/GameData/StarshipLaunchExpansion/Versioning/StarshipLaunchExpansion.version
@@ -1,6 +1,6 @@
 {
 	"NAME":"StarshipLaunchExpansion",
-	"URL":"https://raw.githubusercontent.com/SAMCG14/StarshipLaunchExpansion/Dev/GameData/StarshipLaunchExpansion/Versioning/SLE.version",
+	"URL":"https://raw.githubusercontent.com/SAMCG14/StarshipLaunchExpansion/Dev/GameData/StarshipLaunchExpansion/Versioning/StarshipLaunchExpansion.version",
 	"DOWNLOAD":"https://forum.kerbalspaceprogram.com/index.php?/topic/203952-1122-starship-launch-expansion/",
 	"VERSION":
 	{


### PR DESCRIPTION
Hi @SAMCG14,

The current URL property in the version file is a 404, because it points to a filename `SLE.version` which does not exist. Now it's updated to `StarshipLaunchExpansion.version` which does exist.

Cheers!